### PR TITLE
Port forward bolt

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 docker_run="docker run"
-docker_run="$docker_run -d -p 7474:7474 --env=NEO4J_AUTH=neo4j/$INPUT_PASSWORD neo4j:$INPUT_TAG"
+docker_run="$docker_run -d -p 7474:7474 -p 7687:7687 --env=NEO4J_AUTH=neo4j/$INPUT_PASSWORD neo4j:$INPUT_TAG"
 
 sh -c "$docker_run"


### PR DESCRIPTION
Greetings! 

I was using [neo4j-graphl-js](https://github.com/neo4j-graphql/neo4j-graphql-js) for a university homework and wanted to spin up Neo4J in my CI as a Github Action and was pointed to your repository.

Newer versions of Neo4j communicate via Bolt (port 7687) with various driver so I added port forwarding for that to make it work. It's also included in the [Neo4j's official guide for docker](https://neo4j.com/developer/docker/).